### PR TITLE
Improve BORINGSSL configuration

### DIFF
--- a/cmake/Findsyncme.cmake
+++ b/cmake/Findsyncme.cmake
@@ -17,19 +17,10 @@ get_filename_component(SYNCME_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
 set(SYNCME_INCLUDE_DIR ${SYNCME_ROOT}/lib/include)
 
 # SSL backend selection is controlled by the parent project.
-# When USE_BORINGSSL is enabled, the parent must provide BORINGSSL_INCLUDE_DIR and BORINGSSL_LIBRARIES.
+# When USE_BORINGSSL is enabled, the parent must provide boringssl.cmake
+# which can be found via include(boringssl)
 if(USE_BORINGSSL)
-  add_compile_definitions(USE_BORINGSSL)
-  if(NOT DEFINED BORINGSSL_INCLUDE_DIR)
-    message(FATAL_ERROR "USE_BORINGSSL is ON but BORINGSSL_INCLUDE_DIR is not set")
-  endif()
-  if(NOT DEFINED BORINGSSL_LIBRARIES)
-    message(FATAL_ERROR "USE_BORINGSSL is ON but BORINGSSL_LIBRARIES is not set")
-  endif()
-
-  # Reuse existing OPENSSL_* variables expected by syncme's build scripts.
-  set(OPENSSL_INCLUDE_DIR ${BORINGSSL_INCLUDE_DIR})
-  set(OPENSSL_LIBRARIES ${BORINGSSL_LIBRARIES})
+  message(STATUS "Syncme will be configured with BORINGSSL support")
 endif()
 
 

--- a/dynamic/CMakeLists.txt
+++ b/dynamic/CMakeLists.txt
@@ -11,6 +11,7 @@ message(STATUS "Syncme dynamic added SYNCME_INCLUDE_DIR=${SYNCME_INCLUDE_DIR}")
 add_library(syncmed SHARED ${SOURCES} ${HEADERS} ${SYNCME_VERSION_RC})
 
 if(USE_BORINGSSL)
+  include(boringssl)
   set(_ssl_include_dir ${BORINGSSL_INCLUDE_DIR})
   set(_ssl_libraries ${BORINGSSL_LIBRARIES})
 else()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,6 +4,7 @@ file(GLOB_RECURSE HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h")
 add_library(syncme STATIC ${SOURCES} ${HEADERS}) 
 
 if(USE_BORINGSSL)
+  include(boringssl)
   set(_ssl_include_dir ${BORINGSSL_INCLUDE_DIR})
 else()
   set(_ssl_include_dir ${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
When USE_BORINGSSL is enabled, the parent must provide boringssl.cmake
which can be found via include(boringssl)